### PR TITLE
feat: support url-based fake news validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Node.js
+node_modules/
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -78,6 +78,38 @@ interface = gr.Interface(
 interface.launch()
 ```
 
+### Front-end moderno (React + Vite)
+
+Além da interface em Gradio, o repositório conta com uma aplicação web moderna em React localizada na pasta `frontend/`. Ela consome diretamente a API FastAPI (`/check-news-url`, `/check-news`, `/recent-news` e `/collect-news`) e oferece:
+
+- Formulário para envio da URL completa da notícia a ser analisada;
+- Exibição do veredito com barra de probabilidade, resumo da matéria e orientações de checagem;
+- Painel com as últimas notícias coletadas e botão para disparar a coleta automática.
+
+Para executar o front-end:
+
+```
+cd frontend
+npm install
+npm run dev
+```
+
+Ao abrir a interface, cole o link da matéria (com `http://` ou `https://`) no campo principal. O front-end solicita a checagem via endpoint `/check-news-url`, que faz o scraping do texto, executa o classificador e retorna o veredito acompanhado de um resumo da notícia.
+
+Por padrão a aplicação utiliza `http://localhost:8000` como URL da API. Para apontar para outra instância basta definir a variável `VITE_API_URL` antes de iniciar o servidor de desenvolvimento ou durante o build:
+
+```
+# Linux/macOS
+export VITE_API_URL="https://sua-api"
+npm run dev
+
+# Windows PowerShell
+$env:VITE_API_URL="https://sua-api"
+npm run dev
+```
+
+Para gerar a versão de produção utilize `npm run build` e sirva o conteúdo de `frontend/dist` com o servidor de sua preferência.
+
 ### Validação de Notícias (validar_noticias.py)
 
 Este script permite validar várias notícias em lote, útil para testar o desempenho do modelo com novos dados.

--- a/fake-news-detector-br/app/main.py
+++ b/fake-news-detector-br/app/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, HttpUrl
+from textwrap import shorten
 import uvicorn
+from newspaper import Article
+from newspaper.article import ArticleException
 from .news_collector import run_collector
 from .fake_news_detector import check_news
 from .database import init_db, get_db_connection
@@ -22,10 +25,50 @@ class NewsRequest(BaseModel):
     title: str
     content: str
 
+
 class NewsResponse(BaseModel):
     verdict: str
     probability: float
     message: str
+
+
+class UrlRequest(BaseModel):
+    url: HttpUrl
+
+
+class UrlNewsResponse(NewsResponse):
+    extracted_title: str | None = None
+    content_preview: str | None = None
+    url: HttpUrl
+
+
+VERDICT_MESSAGES = {
+    "VERDADEIRO": "Esta notícia parece ser confiável.",
+    "INDETERMINADO": "Não é possível determinar a veracidade com certeza. Consulte fontes adicionais.",
+    "PROVAVELMENTE FALSO": "Cuidado! Esta notícia pode conter informações falsas.",
+}
+
+
+def build_news_response(verdict: str, probability: float, message_override: str | None = None) -> NewsResponse:
+    message = message_override or VERDICT_MESSAGES.get(verdict, "Verifique com fontes confiáveis.")
+    return NewsResponse(verdict=verdict, probability=probability, message=message)
+
+
+def extract_article_from_url(url: str) -> tuple[str, str]:
+    article = Article(url)
+
+    try:
+        article.download()
+        article.parse()
+    except ArticleException as exc:
+        raise HTTPException(status_code=400, detail="Não foi possível acessar a URL informada.") from exc
+
+    content = (article.text or "").strip()
+    if not content:
+        raise HTTPException(status_code=422, detail="Não foi possível extrair conteúdo da página informada.")
+
+    title = (article.title or "").strip() or "Título não encontrado"
+    return title, content
 
 @app.on_event("startup")
 async def startup_event():
@@ -40,19 +83,7 @@ async def root():
 async def check_news_endpoint(request: NewsRequest):
     try:
         verdict, probability = check_news(request.title, request.content)
-        
-        # Mensagem personalizada baseada no veredito
-        messages = {
-            "VERDADEIRO": "Esta notícia parece ser confiável.",
-            "INDETERMINADO": "Não é possível determinar a veracidade com certeza. Consulte fontes adicionais.",
-            "PROVAVELMENTE FALSO": "Cuidado! Esta notícia pode conter informações falsas."
-        }
-        
-        return NewsResponse(
-            verdict=verdict,
-            probability=probability,
-            message=messages.get(verdict, "Verifique com fontes confiáveis.")
-        )
+        return build_news_response(verdict, probability)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -86,6 +117,29 @@ async def get_recent_news(limit: int = 10):
         return {"news": results}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/check-news-url", response_model=UrlNewsResponse)
+async def check_news_from_url(request: UrlRequest):
+    title, content = extract_article_from_url(str(request.url))
+
+    try:
+        verdict, probability = check_news(title, content)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    base_response = build_news_response(verdict, probability)
+    preview = shorten(" ".join(content.split()), width=320, placeholder="…")
+
+    return UrlNewsResponse(
+        verdict=base_response.verdict,
+        probability=base_response.probability,
+        message=base_response.message,
+        extracted_title=title,
+        content_preview=preview,
+        url=request.url,
+    )
+
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", 8000))

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Detector de Fake News BR</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fake-news-detector-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,409 @@
+.app {
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(226, 232, 240, 0.45) 0%, rgba(241, 245, 249, 0.9) 100%);
+}
+
+.app__wrapper {
+  width: min(1100px, 100% - 2rem);
+  margin: 0 auto;
+  padding: 3rem 0 5rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #0f172a;
+}
+
+header p {
+  margin-top: 0.75rem;
+  font-size: 1.05rem;
+  color: #475569;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.45);
+}
+
+.card + .card {
+  margin-top: 2.25rem;
+}
+
+.check-form {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-group label {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1.05rem;
+}
+
+.form-hint {
+  margin-top: -0.25rem;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.form-group input,
+.form-group textarea {
+  border-radius: 1rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  padding: 1rem 1.1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group textarea {
+  min-height: 180px;
+  resize: vertical;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.button-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.button {
+  border: none;
+  border-radius: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.85rem 1.6rem;
+  font-size: 1rem;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 12px 30px -18px rgba(37, 99, 235, 0.9);
+}
+
+.button--primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 36px -18px rgba(37, 99, 235, 0.9);
+}
+
+.button--ghost {
+  background: rgba(148, 163, 184, 0.15);
+  color: #1f2937;
+}
+
+.button--ghost:not(:disabled):hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.button--outline {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  color: #1f2937;
+}
+
+.button--outline:not(:disabled):hover {
+  border-color: #1d4ed8;
+  color: #1d4ed8;
+}
+
+.alert {
+  border-radius: 0.9rem;
+  padding: 1rem 1.2rem;
+  font-weight: 500;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.alert--error {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.alert--info {
+  background: rgba(96, 165, 250, 0.1);
+  color: #1d4ed8;
+  border: 1px solid rgba(96, 165, 250, 0.2);
+}
+
+.article-preview {
+  margin-top: 1.75rem;
+  padding: 1.5rem;
+  border-radius: 1.2rem;
+  background: rgba(241, 245, 249, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.article-preview h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.article-preview__title {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.article-preview__snippet {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.article-preview__link {
+  justify-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.article-preview__link::after {
+  content: '↗';
+  font-size: 0.85rem;
+}
+
+.article-preview__link:hover {
+  text-decoration: underline;
+}
+
+.result-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.result-header h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.badge--success {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.badge--warning {
+  background: rgba(250, 204, 21, 0.22);
+  color: #92400e;
+}
+
+.badge--danger {
+  background: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}
+
+.probability-meter {
+  margin-top: 1.75rem;
+}
+
+.probability-meter__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  color: #475569;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.probability-meter__track {
+  height: 0.75rem;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.probability-meter__fill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.4s ease, background 0.3s ease;
+}
+
+.probability-meter__fill--success {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.probability-meter__fill--warning {
+  background: linear-gradient(135deg, #facc15, #f97316);
+}
+
+.probability-meter__fill--danger {
+  background: linear-gradient(135deg, #ef4444, #b91c1c);
+}
+
+.analysis-section {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.analysis-card {
+  border-radius: 1.1rem;
+  padding: 1.5rem;
+  background: rgba(241, 245, 249, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.analysis-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.analysis-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.news-section {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.news-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.news-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.news-card {
+  border-radius: 1.2rem;
+  padding: 1.5rem;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.55);
+}
+
+.news-card h4 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  color: #111827;
+}
+
+.news-card p {
+  margin: 0.4rem 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.news-card a {
+  text-decoration: none;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.news-card a:hover {
+  text-decoration: underline;
+}
+
+.loading-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: #1d4ed8;
+  font-weight: 500;
+}
+
+.loading-indicator::before {
+  content: '';
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 3px solid rgba(37, 99, 235, 0.35);
+  border-top-color: #2563eb;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.footer {
+  margin-top: 3rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .app__wrapper {
+    padding: 2.5rem 0 4rem;
+  }
+
+  .card {
+    padding: 1.75rem;
+  }
+
+  .button-group {
+    width: 100%;
+  }
+
+  .button {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,448 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import './App.css';
+
+const API_URL = (import.meta.env.VITE_API_URL ?? 'http://localhost:8000').replace(/\/$/, '');
+
+type CheckResponse = {
+  verdict: string;
+  probability: number;
+  message: string;
+};
+
+type UrlCheckResponse = CheckResponse & {
+  extracted_title: string | null;
+  content_preview: string | null;
+  url: string;
+};
+
+type RecentNewsItem = {
+  id: number | string;
+  title: string;
+  source_name: string | null;
+  source_url: string | null;
+  publish_date: string | null;
+};
+
+type VerdictTone = 'success' | 'warning' | 'danger';
+
+type VerdictConfig = {
+  tone: VerdictTone;
+  headline: string;
+  tips: string[];
+};
+
+type VerdictKey = 'VERDADEIRO' | 'INDETERMINADO' | 'PROVAVELMENTE FALSO' | 'DEFAULT';
+
+const VERDICT_CONFIG: Record<VerdictKey, VerdictConfig> = {
+  VERDADEIRO: {
+    tone: 'success',
+    headline: 'Sinais de conteúdo confiável',
+    tips: [
+      'Ainda assim, confirme a notícia em portais reconhecidos (G1, Agência Brasil, Folha, Estadão).',
+      'Leia a matéria completa antes de compartilhar e confirme se outras fontes também publicaram o conteúdo.',
+      'Mantenha o hábito de acompanhar fontes oficiais relacionadas ao tema tratado.'
+    ]
+  },
+  INDETERMINADO: {
+    tone: 'warning',
+    headline: 'Informações adicionais são necessárias',
+    tips: [
+      'Procure pelo assunto em diferentes portais jornalísticos e compare as versões.',
+      'Verifique se a notícia cita fontes confiáveis, especialistas ou dados verificáveis.',
+      'Desconfie de textos com tom extremamente alarmista ou que incentivem compartilhamentos urgentes.'
+    ]
+  },
+  'PROVAVELMENTE FALSO': {
+    tone: 'danger',
+    headline: 'Alerta: fortes indícios de fake news',
+    tips: [
+      'Não compartilhe antes de buscar confirmação em agências de checagem (Lupa, Aos Fatos, Comprova).',
+      'Pesquise trechos da notícia no Google para verificar se há desmentidos ou notas oficiais.',
+      'Observe se o texto contém erros gramaticais graves, links suspeitos ou promessas de ganhos fáceis.'
+    ]
+  },
+  DEFAULT: {
+    tone: 'warning',
+    headline: 'Verifique manualmente em fontes confiáveis',
+    tips: [
+      'Busque fontes adicionais e priorize veículos de comunicação consolidados.',
+      'Evite compartilhar até ter certeza da procedência da informação.',
+      'Cheque se a notícia possui data, autoria e referências claras.'
+    ]
+  }
+};
+
+const normalizeProbability = (value: number | null | undefined): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+  if (!Number.isFinite(value)) {
+    return value > 0 ? 1 : 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 1) {
+    return 1;
+  }
+  return value;
+};
+
+const extractErrorDetail = (payload: unknown): string | null => {
+  if (payload && typeof payload === 'object' && 'detail' in payload) {
+    const detail = (payload as { detail?: unknown }).detail;
+    if (typeof detail === 'string') {
+      return detail;
+    }
+  }
+  return null;
+};
+
+const formatDate = (value: string | null): string => {
+  if (!value) {
+    return 'Data não informada';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleString('pt-BR', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+};
+
+const toneClassMap: Record<VerdictTone, string> = {
+  success: 'badge--success',
+  warning: 'badge--warning',
+  danger: 'badge--danger'
+};
+
+const meterClassMap: Record<VerdictTone, string> = {
+  success: 'probability-meter__fill probability-meter__fill--success',
+  warning: 'probability-meter__fill probability-meter__fill--warning',
+  danger: 'probability-meter__fill probability-meter__fill--danger'
+};
+
+function App(): JSX.Element {
+  const [url, setUrl] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const [result, setResult] = useState<UrlCheckResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [newsLoading, setNewsLoading] = useState(false);
+  const [newsItems, setNewsItems] = useState<RecentNewsItem[]>([]);
+  const [collecting, setCollecting] = useState(false);
+  const [collectMessage, setCollectMessage] = useState<string | null>(null);
+
+  const fetchRecentNews = useCallback(async () => {
+    setNewsLoading(true);
+    setRequestError(null);
+    try {
+      const response = await fetch(`${API_URL}/recent-news?limit=6`);
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const detail = extractErrorDetail(payload);
+        throw new Error(detail ?? 'Não foi possível carregar as notícias recentes.');
+      }
+
+      const data = (payload as { news?: RecentNewsItem[] } | null)?.news;
+      setNewsItems(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error(error);
+      setRequestError(
+        error instanceof Error
+          ? error.message
+          : 'Erro inesperado ao carregar as notícias recentes.'
+      );
+    } finally {
+      setNewsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchRecentNews();
+  }, [fetchRecentNews]);
+
+  const verdictKey = useMemo<VerdictKey>(() => {
+    if (!result?.verdict) {
+      return 'DEFAULT';
+    }
+    return (result.verdict in VERDICT_CONFIG ? result.verdict : 'DEFAULT') as VerdictKey;
+  }, [result]);
+
+  const verdictConfig = VERDICT_CONFIG[verdictKey];
+  const tone = verdictConfig.tone;
+  const normalizedProbability = normalizeProbability(result?.probability);
+  const probabilityPercent = (normalizedProbability * 100).toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+  });
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    setRequestError(null);
+    setCollectMessage(null);
+
+    const sanitizedUrl = url.trim();
+    if (!sanitizedUrl) {
+      setFormError('Informe a URL completa da notícia que deseja validar.');
+      return;
+    }
+
+    let normalizedUrl: string;
+    try {
+      const parsed = new URL(sanitizedUrl);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new Error('Protocol inválido');
+      }
+      normalizedUrl = parsed.toString();
+    } catch (error) {
+      console.error(error);
+      setFormError('Informe uma URL válida iniciando com http:// ou https://.');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch(`${API_URL}/check-news-url`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          url: normalizedUrl
+        })
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const detail = extractErrorDetail(payload);
+        throw new Error(detail ?? 'Não foi possível verificar a notícia.');
+      }
+
+      setResult(payload as UrlCheckResponse);
+    } catch (error) {
+      console.error(error);
+      setResult(null);
+      setRequestError(
+        error instanceof Error ? error.message : 'Erro inesperado ao verificar a notícia.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClear = () => {
+    setUrl('');
+    setFormError(null);
+    setRequestError(null);
+    setCollectMessage(null);
+    setResult(null);
+  };
+
+  const handleCollectNews = async () => {
+    setCollecting(true);
+    setCollectMessage(null);
+    setRequestError(null);
+    try {
+      const response = await fetch(`${API_URL}/collect-news`, {
+        method: 'POST'
+      });
+
+      const payload = await response.json().catch(() => null);
+      if (!response.ok) {
+        const detail = extractErrorDetail(payload);
+        throw new Error(detail ?? 'Não foi possível iniciar a coleta de notícias.');
+      }
+
+      const message = (payload as { message?: string } | null)?.message ??
+        'Coleta concluída com sucesso.';
+      setCollectMessage(message);
+      await fetchRecentNews();
+    } catch (error) {
+      console.error(error);
+      setRequestError(
+        error instanceof Error ? error.message : 'Erro inesperado ao coletar notícias.'
+      );
+    } finally {
+      setCollecting(false);
+    }
+  };
+
+  return (
+    <div className="app">
+      <div className="app__wrapper">
+        <header>
+          <h1>Detector de Fake News BR</h1>
+          <p>
+            Cole uma URL de notícia para que o sistema faça a leitura automática do conteúdo e aponte o grau de confiabilidade.
+          </p>
+        </header>
+
+        <section className="card">
+          <form className="check-form" onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="news-url">URL da notícia</label>
+              <input
+                id="news-url"
+                name="url"
+                type="url"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="https://www.exemplo.com/noticia-importante"
+                autoComplete="off"
+                inputMode="url"
+              />
+              <small className="form-hint">Cole o link completo começando com http:// ou https://.</small>
+            </div>
+
+            {formError && <div className="alert alert--error">{formError}</div>}
+            {requestError && <div className="alert alert--error">{requestError}</div>}
+            {collectMessage && <div className="alert alert--info">{collectMessage}</div>}
+
+            <div className="button-group">
+              <button className="button button--primary" type="submit" disabled={loading}>
+                {loading ? 'Analisando...' : 'Verificar notícia'}
+              </button>
+              <button
+                className="button button--ghost"
+                type="button"
+                onClick={handleClear}
+                disabled={loading}
+              >
+                Limpar
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {result && (
+          <section className="card">
+            <div className="result-header">
+              <span className={`badge ${toneClassMap[tone]}`}>
+                {result.verdict}
+              </span>
+              <h2>{verdictConfig.headline}</h2>
+              <p>{result.message}</p>
+            </div>
+
+            <div className="article-preview">
+              <h3>Matéria analisada</h3>
+              <p className="article-preview__title">
+                {result.extracted_title ?? 'Título não identificado'}
+              </p>
+              {result.content_preview && (
+                <p className="article-preview__snippet">{result.content_preview}</p>
+              )}
+              <a
+                className="article-preview__link"
+                href={result.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Ler notícia original
+              </a>
+            </div>
+
+            <div className="probability-meter">
+              <div className="probability-meter__label">
+                <span>Probabilidade de ser fake</span>
+                <strong>{probabilityPercent}%</strong>
+              </div>
+              <div className="probability-meter__track">
+                <div
+                  className={meterClassMap[tone]}
+                  style={{ width: `${Math.round(normalizedProbability * 100)}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="analysis-section">
+              <div className="analysis-card">
+                <h3>Como interpretar este resultado</h3>
+                <ul>
+                  {verdictConfig.tips.map((tip) => (
+                    <li key={tip}>{tip}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="analysis-card">
+                <h3>Boas práticas de verificação</h3>
+                <ul>
+                  <li>Pesquise o assunto em mais de uma fonte jornalística.</li>
+                  <li>Confirme a data, autoria e referências da notícia.</li>
+                  <li>Desconfie de mensagens que pedem compartilhamentos imediatos.</li>
+                </ul>
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section className="card news-section">
+          <div className="news-header">
+            <h2>Últimas notícias coletadas</h2>
+            <div className="button-group">
+              <button
+                className="button button--outline"
+                type="button"
+                onClick={fetchRecentNews}
+                disabled={newsLoading}
+              >
+                {newsLoading ? 'Atualizando...' : 'Atualizar lista'}
+              </button>
+              <button
+                className="button button--primary"
+                type="button"
+                onClick={handleCollectNews}
+                disabled={collecting}
+              >
+                {collecting ? 'Coletando...' : 'Rodar coleta automática'}
+              </button>
+            </div>
+          </div>
+
+          {newsLoading && <div className="loading-indicator">Carregando notícias...</div>}
+
+          {!newsLoading && newsItems.length === 0 && (
+            <p>Sem notícias cadastradas até o momento. Utilize a coleta automática para alimentar o banco.</p>
+          )}
+
+          {newsItems.length > 0 && (
+            <div className="news-grid">
+              {newsItems.map((item) => (
+                <article className="news-card" key={item.id}>
+                  <h4>{item.title}</h4>
+                  <p>
+                    <strong>Fonte:</strong> {item.source_name ?? 'Não informada'}
+                  </p>
+                  <p>
+                    <strong>Publicado em:</strong> {formatDate(item.publish_date)}
+                  </p>
+                  {item.source_url && item.source_url.startsWith('http') && (
+                    <p>
+                      <a href={item.source_url} target="_blank" rel="noopener noreferrer">
+                        Ler matéria original
+                      </a>
+                    </p>
+                  )}
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <p className="footer">
+          A API aceita requisições REST padrão. Defina a variável de ambiente <code>VITE_API_URL</code> para apontar o front-end
+          para outra origem.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,28 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #f1f5f9;
+  color: #0f172a;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f1f5f9;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that scrapes article content from a submitted URL and reuses the existing classifier response helpers
- update the React single-page app to collect a news URL, call the new endpoint and display the extracted headline/summary with the verdict
- refresh styles and README instructions so the workflow focuses on URL-based validation

## Testing
- ✅ `python -m compileall fake-news-detector-br/app/main.py`
- ⚠️ `npm install` *(fails: 403 Forbidden from registry in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d174475820832586ebcd0adf520ff7